### PR TITLE
[#44000493] Remove dependency on deployment repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ You will need access to the repos:
 
 - `puppet` obviously
 - `vcloud-templates` for node definitions
-- `deployment` for extdata
 
 ## Setup
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -88,9 +88,9 @@ Vagrant::Config.run do |config|
           "../puppet"
       end
 
-      c.vm.share_folder "pm-extdata",
-        "/usr/share/puppet/production/current/extdata",
-        "../deployment/puppet/extdata"
+      c.vm.share_folder "extdata",
+        "/tmp/vagrant-puppet/extdata",
+        "../puppet/extdata"
 
       c.vm.provision :puppet do |puppet|
         puppet.manifest_file = "site.pp"
@@ -99,6 +99,7 @@ Vagrant::Config.run do |config|
           "../puppet/modules",
           "../puppet/vendor/modules",
         ]
+        puppet.options = ["--environment", "vagrant"]
         puppet.facter = {
           :govuk_class => node_opts["class"],
           :govuk_provider => "sky",


### PR DESCRIPTION
Switch to the extdata directory within the Puppet repo. Provides a new
mount, parallel to manifests and modules. New `--environment vagrant`
argument ensures that the correct extdata files are picked up.
## 

See parent PR: https://github.com/alphagov/puppet/pull/407
