### PR TITLE
[#52201683] Added vagrant support for new puppetmaster node

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -82,7 +82,7 @@ Vagrant::Config.run do |config|
 
       # Additional shared folders for Puppet Master nodes.
       # These can't been NFS because OSX won't export overlapping paths.
-      if node_opts["class"] == "puppet"
+      if node_opts["class"] == "puppetmaster" or node_opts["class"] == "puppet"
         c.vm.share_folder "pm-puppet",
           "/usr/share/puppet/production/current",
           "../puppet"


### PR DESCRIPTION
Mounting additional folders for Puppet Masters to run with their
normal production-like configurations.
SHA: 0a72d9f6bcd29a99391ba0c0b4a92ba06a8e8533

_See puppet.conf as it refers to these path for modulepath & manifestpath_
