### PR TITLE
use vagrant-cachier if present

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -50,6 +50,9 @@ def nodes_from_json
 end
 
 Vagrant.configure("2") do |config|
+  if config.respond_to? :cache
+    config.cache.auto_detect = true
+  end
   nodes_from_json.each do |node_name, node_opts|
     config.vm.define node_name do |c|
       box_name, box_url = get_box(

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -50,9 +50,6 @@ def nodes_from_json
 end
 
 Vagrant.configure("2") do |config|
-  if config.respond_to? :cache
-    config.cache.auto_detect = true
-  end
   nodes_from_json.each do |node_name, node_opts|
     config.vm.define node_name do |c|
       box_name, box_url = get_box(
@@ -69,6 +66,10 @@ Vagrant.configure("2") do |config|
       }
 
       c.vm.provider :virtualbox do |vb|
+        if config.respond_to? :cache
+          config.cache.auto_detect = true
+        end
+
         modifyvm_args = ['modifyvm', :id]
 
         # Mitigate boot hangs.


### PR DESCRIPTION
[vagrant-cachier](https://github.com/fgrehm/vagrant-cachier) is a plugin which caches packages from various repositories for your vagrant boxes.

If you have it installed, we should use it. But we shouldn't break if you don't have it.

(You can [install it using boxen](https://github.com/alphagov/gds-boxen/blob/master/modules/people/manifests/philandstuff.pp#L37))
