### PR TITLE
Fix SSH issues with Vagrant 1.2.7

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -106,8 +106,6 @@ def vagrant_config(config, version)
         c.vm.provider(:virtualbox) { |vb| vb.customize(modifyvm_args) }
       end
 
-      c.ssh.forward_agent = true
-
       if version < 2
         c.vm.share_folder "govuk", "/var/govuk", "..", :nfs => true
         c.vm.share_folder "extdata",


### PR DESCRIPTION
We no longer need ssh agent forward in the Vagrantfile
as it has been disable in the boxes ssh config
