### PR TITLE
Bump minimum required version.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,6 @@
 require 'json'
 
-min_required_vagrant_version = '1.2.3'
+min_required_vagrant_version = '1.3.0'
 
 # Construct box name and URL from distro and version.
 def get_box(dist, version)


### PR DESCRIPTION
We need https://github.com/mitchellh/vagrant/commit/9e38601f185e4ed73aeb61f1ce47b66658b37351#diff-4ac32a78649ca5bdd8e0ba38b7006a1eR68 to deal with our change to relative paths in https://github.gds/gds/puppet/commit/7538cf426d8b8fae9ff2a3407c5a7420d88ac2c5
