### PR TITLE
Toggle using NFS for synced folders.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -85,7 +85,12 @@ Vagrant.configure("2") do |config|
       end
 
       c.vm.provider(:virtualbox) { |vb| vb.customize(modifyvm_args) }
-      c.vm.synced_folder "..", "/var/govuk", :nfs => true
+
+      if ENV['VAGRANT_GOVUK_NFS'] == "no"
+        c.vm.synced_folder "..", "/var/govuk"
+      else
+        c.vm.synced_folder "..", "/var/govuk", :nfs => true
+      end
 
       # Additional shared folders for Puppet Master nodes.
       # These can't be NFS because OSX won't export overlapping paths.


### PR DESCRIPTION
While NFS is more performant it has issues when using at least one of our VPNs. The performance gain is not as useful if you are only checking puppet runs.

Add an environment variable VAGRANT_GOVUK_NFS to toggle the use of NFS for synced folders.
Default to using NFS.

If you dont want to use NFS set VAGRANT_GOVUK_NFS=no as an environment variable.

e.g

$ VAGRANT_GOVUK_NFS=no vagrant up box.example
