### PR TITLE
Enable vagrant-cachier if available

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -57,6 +57,11 @@ if Vagrant::VERSION < min_required_vagrant_version
 end
 
 Vagrant.configure("2") do |config|
+  # Enable vagrant-cachier if available.
+  if Vagrant.has_plugin?("vagrant-cachier")
+    config.cache.auto_detect = true
+  end
+
   nodes_from_json.each do |node_name, node_opts|
     config.vm.define node_name do |c|
       box_name, box_url = get_box(


### PR DESCRIPTION
This dramatically speeds up provisioning times. Enable the plugin if
installed. It can be installed using Boxen. I'm sure that we did this once,
but I can't find any record of it. However it now seems to work better with
Lucid.

This repo doesn't currently support VMware so I'm not going to bother
feature flagging it or wrapping it in a provider block.
