### PR TITLE
[#54693536] Update basebox images

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@ min_required_vagrant_version = '1.3.0'
 # Construct box name and URL from distro and version.
 def get_box(dist, version)
   dist    ||= "precise"
-  version ||= "20130712"
+  version ||= "20140318"
 
   name  = "govuk_dev_#{dist}64_#{version}"
   url   = "http://gds-boxes.s3.amazonaws.com/#{name}.box"


### PR DESCRIPTION
Includes Puppet 3.4 installed from a Debian package: alphagov/boxes#4

This will be downloaded automatically the next time someone brings up a box
(`vagrant up`) from fresh (clean install or after `vagrant destroy`).
