### PR TITLE
[#68346578] Set TLD to `development` for Puppet

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -70,7 +70,7 @@ Vagrant.configure("2") do |config|
       )
       c.vm.box = box_name
       c.vm.box_url = box_url
-      c.vm.hostname = node_name
+      c.vm.hostname = "#{node_name}.development"
       c.vm.network :private_network, {
         :ip => node_opts["ip"],
         :netmask => "255.255.000.000"


### PR DESCRIPTION
So that it matches the `govuk::host` entries in Puppet. This prevents the
machine's FQDN from changing on the first Puppet run, now that we purge
unmanaged `hosts(5)` entries (which gets rid of `127.0.1.1`).
