### PR TITLE
Do not set FACTER_govuk_platform when running puppet

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -106,7 +106,7 @@ Vagrant.configure("2") do |config|
         c.vm.synced_folder "../puppet", "/usr/share/puppet/production/current"
       end
 
-      c.vm.provision :shell, :inline => "ENVIRONMENT=vagrant FACTER_govuk_platform=staging /var/govuk/puppet/tools/puppet-apply #{ENV['VAGRANT_GOVUK_PUPPET_OPTIONS']}"
+      c.vm.provision :shell, :inline => "ENVIRONMENT=vagrant /var/govuk/puppet/tools/puppet-apply #{ENV['VAGRANT_GOVUK_PUPPET_OPTIONS']}"
     end
   end
 end


### PR DESCRIPTION
We are removing this facter variable, so it's not longer necessary to set it
when running puppet.
