### PR TITLE
[Fixes #69925732] Use vcloud-launcher configs in govuk-provisioning

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,13 +21,13 @@ if Vagrant::VERSION < min_required_vagrant_version
   exit 1
 end
 
+nodes = load_nodes()
 Vagrant.configure("2") do |config|
   # Enable vagrant-cachier if available.
   if Vagrant.has_plugin?("vagrant-cachier")
     config.cache.auto_detect = true
   end
 
-  nodes = load_nodes()
   nodes.each do |node_name, node_opts|
     config.vm.define node_name do |c|
       box_name, box_url = get_box(

--- a/load_nodes.rb
+++ b/load_nodes.rb
@@ -1,0 +1,39 @@
+require 'json'
+
+# Load node definitions from the JSON in the vcloud-templates repo parallel
+# to this.
+def load_nodes
+  json_dir = File.expand_path("../../vcloud-templates/machines", __FILE__)
+  json_local = File.expand_path("../nodes.local.json", __FILE__)
+
+  unless File.exists?(json_dir)
+    puts "Unable to find nodes in 'vcloud-templates' repo"
+    puts
+    return {}
+  end
+
+  json_files = Dir.glob(
+    File.join(json_dir, "**", "*.json")
+  )
+
+  nodes = Hash[
+    json_files.map { |json_file|
+      node = JSON.parse(File.read(json_file))
+      name = node["vm_name"] + "." + node["zone"]
+
+      # Ignore physical attributes.
+      node.delete("memory")
+      node.delete("num_cores")
+
+      [name, node]
+    }
+  ]
+
+  # Local JSON file can override node properties like "memory".
+  if File.exists?(json_local)
+    nodes_local = JSON.parse(File.read(json_local))
+    nodes_local.each { |k,v| nodes[k].merge!(v) if nodes.has_key?(k) }
+  end
+
+  nodes
+end

--- a/load_nodes.rb
+++ b/load_nodes.rb
@@ -1,37 +1,60 @@
-require 'json'
+require 'yaml'
 
-# Load node definitions from the JSON in the vcloud-templates repo parallel
-# to this.
+# Load node definitions from the vcloud-launcher YAML in the
+# govuk-provisioning repo parallel to this.
 def load_nodes
-  json_dir = File.expand_path("../../vcloud-templates/machines", __FILE__)
-  json_local = File.expand_path("../nodes.local.json", __FILE__)
+  yaml_dir = File.expand_path(
+    "../../govuk-provisioning/vcloud-launcher/production_skyscape/",
+    __FILE__
+  )
+  yaml_local = File.expand_path("../nodes.local.yaml", __FILE__)
 
-  unless File.exists?(json_dir)
-    puts "Unable to find nodes in 'vcloud-templates' repo"
+  # DEPRECATED
+  json_local = File.expand_path("../nodes.local.json", __FILE__)
+  if File.exists?(json_local)
+    $stderr.puts "ERROR: nodes.local.json is deprecated. Please convert it to YAML"
+    exit 1
+  end
+
+  unless File.exists?(yaml_dir)
+    puts "Unable to find nodes in 'govuk-provisioning' repo"
     puts
     return {}
   end
 
-  json_files = Dir.glob(
-    File.join(json_dir, "**", "*.json")
+  yaml_files = Dir.glob(
+    File.join(yaml_dir, "*.yaml")
   )
 
   nodes = Hash[
-    json_files.map { |json_file|
-      node = JSON.parse(File.read(json_file))
-      name = node["vm_name"] + "." + node["zone"]
+    yaml_files.flat_map { |yaml_file|
+      YAML::load_file(yaml_file).fetch('vapps').map { |vapp|
+        name    = vapp.fetch('name')
+        vm      = vapp.fetch('vm')
+        network = vm.fetch('network_connections').first
+        vdc     = network.fetch('name').downcase
 
-      # Ignore physical attributes.
-      node.delete("memory")
-      node.delete("num_cores")
+        name = "#{name}.#{vdc}"
+        config = {
+          :ip => network.fetch('ip_address'),
+        }
 
-      [name, node]
+        [name, config]
+      }
     }
   ]
 
-  # Local JSON file can override node properties like "memory".
-  if File.exists?(json_local)
-    nodes_local = JSON.parse(File.read(json_local))
+  # Local YAML file can override node properties like "memory". It should
+  # look like:
+  #
+  # ---
+  # machine1.vdc1:
+  #   memory: 128
+  # machine2.vdc2:
+  #   memory: 4096
+  #
+  if File.exists?(yaml_local)
+    nodes_local = YAML::load_file(yaml_local)
     nodes_local.each { |k,v| nodes[k].merge!(v) if nodes.has_key?(k) }
   end
 


### PR DESCRIPTION
vcloud-templates and vcloud-box-spinner are dead. This is a simpler version
of Nicolas' yaml_input branch which:
- Uses the updated syntax of vcloud-launcher
- Only takes the required items out of each vApp entry
- Doesn't add disks - I'll create a separate story for that
- Removes support for JSON - we no longer need it

It will raise an error if you have an old `nodes.local.json` file.
