### PR TITLE
Use string key instead of symbol for IP

### DIFF
--- a/load_nodes.rb
+++ b/load_nodes.rb
@@ -36,7 +36,7 @@ def load_nodes
 
         name = "#{name}.#{vdc}"
         config = {
-          :ip => network.fetch('ip_address'),
+          'ip' => network.fetch('ip_address'),
         }
 
         [name, config]


### PR DESCRIPTION
This caused Vagrant to blow up when setting the IP address because it
received a nil value.

/cc @rjw1 
