### PR TITLE
Use vcloud-launcher configs from Preview

### DIFF
--- a/load_nodes.rb
+++ b/load_nodes.rb
@@ -4,7 +4,7 @@ require 'yaml'
 # govuk-provisioning repo parallel to this.
 def load_nodes
   yaml_dir = File.expand_path(
-    "../../govuk-provisioning/vcloud-launcher/production_skyscape/",
+    "../../govuk-provisioning/vcloud-launcher/preview_carrenza/",
     __FILE__
   )
   yaml_local = File.expand_path("../nodes.local.yaml", __FILE__)


### PR DESCRIPTION
Instead of Production because:
- they contain "upcoming" machines like `transition-postgresql-master-1`
  which haven't been created in Production yet.
- have a more reasonable count of machines whilst still being
  representative, like two instead of three `backend-N` machines.
