### PR TITLE
Update vagrant box to 20140829

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,7 +8,7 @@ min_required_vagrant_version = '1.3.0'
 # Construct box name and URL from distro and version.
 def get_box(dist, version, provider)
   dist    ||= "precise"
-  version ||= "20140430"
+  version ||= "20140829"
 
   if provider == "vmware_fusion"
     name  = "govuk_dev_#{dist}64_vmware_fusion_#{version}"


### PR DESCRIPTION
I have updated our Vagrant boxes to 20140829, which is based on Ubuntu
12.04.5 with the latest lts-trusty kernel. We should use this.

I've tested it - the jumpbox comes up fine (it's already been tested
against the full dev VM).
