### PR TITLE
[#64650014] Changes to support Hiera eYAML GPG

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -80,15 +80,15 @@ Vagrant.configure("2") do |config|
         c.vm.synced_folder "..", "/var/govuk", :nfs => true
       end
 
-      # Additional shared folders for Puppet Master nodes.
       # These can't be NFS because OSX won't export overlapping paths.
+      c.vm.synced_folder "../puppet/gpg", "/etc/puppet/gpg"
+      # Additional shared folders for Puppet Master nodes.
       if node_name =~ /^puppetmaster/
         c.vm.synced_folder "../puppet", "/usr/share/puppet/production/current"
       end
 
       # run a script to partition extra disks for lvm if they exist.
-      c.vm.provision :shell, :inline =>"/var/govuk/puppet/tools/partition-disks"
-
+      c.vm.provision :shell, :inline => "/var/govuk/puppet/tools/partition-disks"
       c.vm.provision :shell, :inline => "ENVIRONMENT=vagrant /var/govuk/puppet/tools/puppet-apply #{ENV['VAGRANT_GOVUK_PUPPET_OPTIONS']}"
     end
   end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,7 +8,7 @@ min_required_vagrant_version = '1.3.0'
 # Construct box name and URL from distro and version.
 def get_box(dist, version, provider)
   dist    ||= "precise"
-  version ||= "20140829"
+  version ||= "20140919"
 
   if provider == "vmware_fusion"
     name  = "govuk_dev_#{dist}64_vmware_fusion_#{version}"


### PR DESCRIPTION
**DEPENDS ON https://github.gds/gds/puppet/pull/2149**

Use Vagrant box version `20140919`, which includes the `ruby-hiera-eyaml-gpg` package.

Also, ensure that the `tools/copy-hiera-gpg-keys` script added in [gds/puppet#2149](https://github.gds/gds/puppet/pull/2149) is called to copy any test GPG keys (used for testing encrypted Hiera data under [alphagov/vagrant-govuk](https://github.com/alphagov/vagrant-govuk)) to `/etc/puppet/gpg` so that Puppet is able to decrypt the Hiera data.
