### PR TITLE
[#79450194] Upgrade Vagrant box to use Puppet 3.6

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,7 +8,7 @@ min_required_vagrant_version = '1.3.0'
 # Construct box name and URL from distro and version.
 def get_box(dist, version, provider)
   dist    ||= "precise"
-  version ||= "20140919"
+  version ||= "20141013"
 
   if provider == "vmware_fusion"
     name  = "govuk_dev_#{dist}64_vmware_fusion_#{version}"


### PR DESCRIPTION
Upgrade the Vagrant box versions in `Vagrantfile` to use the
latest box images which install Puppet 3.6 by default.

Without this, Puppet will upgrade itself to version 3.6 but will show
errors on the first run.
