### PR TITLE
Ignore `nodes.local.yaml`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .vagrant
 .bundle/
 vendor/
-nodes.local.json
+nodes.local.yaml


### PR DESCRIPTION
Commit 530ff06 switched `vagrant-govuk` to use YAML for its
configuration and 7638570 updated the documentation to use
`nodes.local.yaml` rather than `nodes.local.json` for local node
configuration.

Update the `.gitignore` file to reflect the changes in the above
commits.
