### PR TITLE
Update vagrant box to 20141112 version

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,7 +8,7 @@ min_required_vagrant_version = '1.3.0'
 # Construct box name and URL from distro and version.
 def get_box(dist, version, provider)
   dist    ||= "precise"
-  version ||= "20141013"
+  version ||= "20141112"
 
   if provider == "vmware_fusion"
     name  = "govuk_dev_#{dist}64_vmware_fusion_#{version}"


### PR DESCRIPTION
This box includes a version of hiera-eyaml-gpg which does not pollute
the environment by requiring GNUPGHOME to be set, which we need to avoid
conflicts between the use of GPG in puppet and the use of GPG by puppet
or the things it is trying to manage.
