### PR TITLE
Try to be more intelligent about box_dist

### DIFF
--- a/load_nodes.rb
+++ b/load_nodes.rb
@@ -39,6 +39,12 @@ def load_nodes
           'ip' => network.fetch('ip_address'),
         }
 
+        ['precise', 'trusty'].each do |dist|
+          if vapp['vapp_template_name'].include? dist
+            config['box_dist'] = dist
+          end
+        end
+
         [name, config]
       }
     }


### PR DESCRIPTION
If a vApp in govuk-provisioning has a template name which includes the string 'trusty', we should not require people to include it in their `nodes.local.yaml` file.

We could make this more robust based on the existing pattern for template names, but we didn't want to make too many assumptions about how those are structured.

@timmow and I aren't sure this is the best solution but we'd like to hear what other people think.
