### PR TITLE
Sort the list of nodes when they're output

### DIFF
--- a/load_nodes.rb
+++ b/load_nodes.rb
@@ -61,5 +61,5 @@ def load_nodes
     nodes_local.each { |k,v| nodes[k].merge!(v) if nodes.has_key?(k) }
   end
 
-  nodes
+  Hash[nodes.sort]
 end


### PR DESCRIPTION
`nodes` is a hash where the keys are the names of machines. Calling `sort()` on the hash turns it into a nested array, which has to be put back into a hash.

This makes it much easier to read the output of `vagrant status` because the machines are ordered by name instead of by vDC.
