### PR TITLE
Default to Ubuntu 14.04 Trusty

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,7 +7,7 @@ min_required_vagrant_version = '1.3.0'
 
 # Construct box name and URL from distro and version.
 def get_box(dist, version, provider)
-  dist    ||= "precise"
+  dist    ||= "trusty"
   version ||= "20141112"
 
   if provider == "vmware_fusion"


### PR DESCRIPTION
The vast majority of our machines are running Trusty now, so it should be the default when bringing up a local copy of a machine.
