### PR TITLE
Change netmask to 255.0.0.0

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -46,7 +46,7 @@ Vagrant.configure("2") do |config|
       c.vm.hostname = "#{node_name}.development"
       c.vm.network :private_network, {
         :ip => node_opts["ip"],
-        :netmask => "255.255.000.000"
+        :netmask => "255.000.000.000"
       }
 
       modifyvm_args = ['modifyvm', :id]


### PR DESCRIPTION
Change the netmask for each VM's private network adapter to use
255.000.000.000, which gives us a 10.0.0.1/8 subnet.

Previously this was set to 255.255.0.0, which is equivalent to a
10.0.0.1/16 subnet, which we assign to each of the vDCs in our Preview
environment.

Broadening this subnet is preferable because there's no reason for us to
segregate our machines in a Vagrant environment and we have no way of
fully emulating that segregation if we wanted to.

Furthermore, this should prevent VMs from blocking requests that are
subject to SNAT rules and so appear to be from an unauthorised IP
address. I saw this happening for Icinga NRPE checks that crossed
between vDCs, e.g. going from 10.0.0.20 (monitoring-1.management) to
10.7.0.16 (api-1.api).

Because the Vagrant netmask was so restrictive, traffic between those
machines was routing over the default gateway and using the NAT adapter
in Virtualbox, meaning that the packets had a source IP of 10.7.0.1 (due
to the SNAT rule) when they arrived at the api-1.api box. The NRPE
daemon was then rejecting the requests as 10.7.0.1 did not match the
monitoring-1 machine's IP address.
