### PR TITLE
[#88908646] Specify owner and group of GPG mount

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -83,7 +83,7 @@ Vagrant.configure("2") do |config|
       end
 
       # These can't be NFS because OSX won't export overlapping paths.
-      c.vm.synced_folder "../puppet/gpg", "/etc/puppet/gpg"
+      c.vm.synced_folder "../puppet/gpg", "/etc/puppet/gpg", :owner => 'puppet', :group => 'puppet'
       # Additional shared folders for Puppet Master nodes.
       if node_name =~ /^puppetmaster/
         c.vm.synced_folder "../puppet", "/usr/share/puppet/production/current"


### PR DESCRIPTION
We provision Vagrant VMs in two ways:
- By running `govuk_puppet` from on the machine
- By running `vagrant provision` from the host machine

`govuk_puppet` has been broken because the puppetmaster process runs as the puppet user, which did not have access to read the GPG mount (it's owned by `vagrant:vagrant` by default).

Changing the owner and group to the puppet user fixes the issue because `vagrant provision` runs as the vagrant user but uses sudo, so it can read the directory contents anyway.

This issue was the one that prompted us to look at file permissions: https://github.com/sihil/hiera-eyaml-gpg/issues/10
