### PR TITLE
Update default hostname for machines

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -43,7 +43,7 @@ Vagrant.configure("2") do |config|
       )
       c.vm.box = box_name
       c.vm.box_url = box_url
-      c.vm.hostname = "#{node_name}.development"
+      c.vm.hostname = "#{node_name}.dev.gov.uk"
       c.vm.network :private_network, {
         :ip => node_opts["ip"],
         :netmask => "255.000.000.000"


### PR DESCRIPTION
This was changed from `development` to `dev.gov.uk` in https://github.gds/gds/puppet/commit/60b440. I am updating the Vagrantfile pre-amble to match what is pulled from Puppet. This caused an issue primarily with puppetmaster-1 where the certificate created for the hostname didn't match the certificate hostname that was created in https://github.gds/gds/puppet/commit/e4b61ba57b0d4ff5c8f08d3fd51b9af3ceb200d6 (or at least I _think_ that's what the problem is).
