### PR TITLE
Add DR nodes for Vagrant environment

### DIFF
--- a/load_nodes.rb
+++ b/load_nodes.rb
@@ -4,7 +4,7 @@ require 'yaml'
 # govuk-provisioning repo parallel to this.
 def load_nodes
   yaml_dir = File.expand_path(
-    "../../govuk-provisioning/vcloud-launcher/integration_carrenza/",
+    "../../govuk-provisioning/vcloud-launcher/*integration_carrenza/",
     __FILE__
   )
   yaml_local = File.expand_path("../nodes.local.yaml", __FILE__)
@@ -16,7 +16,7 @@ def load_nodes
     exit 1
   end
 
-  unless File.exists?(yaml_dir)
+  unless Dir.glob(yaml_dir).any?
     puts "Unable to find nodes in 'govuk-provisioning' repo"
     puts
     return {}


### PR DESCRIPTION
This allows us to bring up DR nodes in the Vagrant environment. The DR directories are different (precursored with "dr_") so search for all environments that are related.

File.exist() does not work with globs, so search through the directories instead.
