### PR TITLE
Amend link to govuk-puppet repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Vagrant node definitions for GOV.UK
 
 You will need access to the repos:
 
-- [`govuk-puppet`](https://github.com/alphagov/govuk-puppet) obviously
+- [`govuk-puppet`](https://github.com/alphagov/govuk-puppet) for configuration management of the nodes
 - `govuk-provisioning` for node definitions
 
 ## Setup

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Vagrant node definitions for GOV.UK
 
 You will need access to the repos:
 
-- `puppet` obviously
+- [`govuk-puppet`](https://github.com/alphagov/govuk-puppet) obviously
 - `govuk-provisioning` for node definitions
 
 ## Setup


### PR DESCRIPTION
This repo has moved from an internal repo, to a public one on Github.com. In the process it has changed name.
I've also taken the opportunity to replace the word 'obviously' with a short statement of why this repository is needed.
